### PR TITLE
Fix sendMessage API method parameter order

### DIFF
--- a/src/features/messages/api/index.ts
+++ b/src/features/messages/api/index.ts
@@ -17,5 +17,5 @@ export const sendMessage: <T extends object>(channelId: string, requestBody: T) 
     channelId: string,
     requestBody: T
 ): Promise<ApiResponse<void>> => {
-    return postSingleWithPathVariable<T, void>(API_ENDPOINTS.MESSAGES.SEND_MESSAGE, requestBody, "", { channelId });
+    return postSingleWithPathVariable<T, void>("", requestBody, API_ENDPOINTS.MESSAGES.SEND_MESSAGE, { channelId });
 };


### PR DESCRIPTION
- Corrected parameter order in postSingleWithPathVariable method call
- Swapped path variable and endpoint parameters to match expected method signature
- Ensures proper routing for sending messages through the API